### PR TITLE
toplevel variable was being declared implicitly.

### DIFF
--- a/domready.js
+++ b/domready.js
@@ -32,7 +32,8 @@
 var domReady = (function() {
 
     var w3c = !!document.addEventListener,
-        loaded = toplevel = false,
+        loaded = false,
+        toplevel = false,
         fns = [];
     
     if (w3c) {


### PR DESCRIPTION
even if it's declared in a closure, implicit variables leak.

![example leakiness](https://img.skitch.com/20110930-bm7qcpayk1atn2rq1j3wiwy9ge.jpg)
